### PR TITLE
set build context to puppetdb

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -23,7 +23,7 @@ jobs:
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           build_args: 'PUPPET_RELEASE=7,PUPPET_VERSION=${{ github.ref_name }}}}'
           build_arch: linux/amd64,linux/arm64
-          buildfile: 'puppetdb/Dockerfile'
+          build_context: puppetdb
         if: ${{ startsWith(github.ref_name, '7') }}
 
       - name: Build PuppetDB 8 container
@@ -32,5 +32,5 @@ jobs:
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           build_args: 'PUPPET_RELEASE=8,PUPPET_VERSION=${{ github.ref_name }}}}'
           build_arch: linux/amd64,linux/arm64
-          buildfile: 'puppetdb/Dockerfile'
+          build_context: puppetdb
         if: ${{ startsWith(github.ref_name, '8') }}


### PR DESCRIPTION
- with context set, we dont need to specify the Dockerfile
- as long as it is Dockerfile and no other name