### PR TITLE
Update and fix GitHub Actions release workflow

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -21,14 +21,14 @@ jobs:
         run: |
           TAG=${{ github.ref_name }}
           echo "PUPPET_RELEASE=${TAG:0:1}" >> $GITHUB_ENV
-          echo "PUPPETSERVER_VERSION=${TAG}" >> $GITHUB_ENV
-      - name: Build Puppetserver ${{ env.PUPPETSERVER_VERSION }} container
+          echo "PUPPETDB_VERSION=${TAG}" >> $GITHUB_ENV
+      - name: Build PuppetDB ${{ env.PUPPETDB_VERSION }} container
         uses: voxpupuli/gha-build-and-publish-a-container@v2
         with:
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           build_args: |
             PUPPET_RELEASE=${{ env.PUPPET_RELEASE }}
-            PUPPETSERVER_VERSION=${{ env.PUPPETSERVER_VERSION }}
+            PUPPETDB_VERSION=${{ env.PUPPETDB_VERSION }}
           build_arch: linux/amd64 #,linux/arm64
-          build_context: puppetserver
-          buildfile: puppetserver/Dockerfile
+          build_context: puppetdb
+          buildfile: puppetdb/Dockerfile

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -17,26 +17,18 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Build PuppetDB 7 container
+      - name: Set variables
+        run: |
+          TAG=${{ github.ref_name }}
+          echo "PUPPET_RELEASE=${TAG:0:1}" >> $GITHUB_ENV
+          echo "PUPPETSERVER_VERSION=${TAG}" >> $GITHUB_ENV
+      - name: Build Puppetserver ${{ env.PUPPETSERVER_VERSION }} container
         uses: voxpupuli/gha-build-and-publish-a-container@v2
         with:
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           build_args: |
-            PUPPET_RELEASE=7
-            PUPPET_VERSION=${{ github.ref_name }}
+            PUPPET_RELEASE=${{ env.PUPPET_RELEASE }}
+            PUPPETSERVER_VERSION=${{ env.PUPPETSERVER_VERSION }}
           build_arch: linux/amd64 #,linux/arm64
-          build_context: puppetdb
-          buildfile: puppetdb/Dockerfile
-        if: ${{ startsWith(github.ref_name, '7') }}
-
-      - name: Build PuppetDB 8 container
-        uses: voxpupuli/gha-build-and-publish-a-container@v2
-        with:
-          registry_password: ${{ secrets.GITHUB_TOKEN }}
-          build_args: |
-            PUPPET_RELEASE=8
-            PUPPET_VERSION=${{ github.ref_name }}
-          build_arch: linux/amd64 #,linux/arm64
-          build_context: puppetdb
-          buildfile: puppetdb/Dockerfile
-        if: ${{ startsWith(github.ref_name, '8') }}
+          build_context: puppetserver
+          buildfile: puppetserver/Dockerfile


### PR DESCRIPTION
The current workflow passes a build argument `PUPPET_VERSION` whilst the Dockerfile does not use it, instead it expects `PUPPETDB_VERSION`.

Reworked the workflow so that the same job can be used to release different versions of PuppetDB depending the tag that triggered the workflow run.