### PR TITLE
Remove deprecated Xloggc

### DIFF
--- a/puppetdb/Dockerfile
+++ b/puppetdb/Dockerfile
@@ -30,7 +30,7 @@ ENV PUPPETDB_POSTGRES_HOSTNAME="postgres" \
     USE_PUPPETSERVER=true \
 # this value may be set by users, keeping in mind that some of these values are mandatory
 # -Djavax.net.debug=ssl may be particularly useful to set for debugging SSL
-    PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m -XX:+UseParallelGC -Xloggc:$LOGDIR/puppetdb_gc.log -Djdk.tls.ephemeralDHKeySize=2048"
+    PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m -XX:+UseParallelGC -Xlog:gc:$LOGDIR/puppetdb_gc.log -Djdk.tls.ephemeralDHKeySize=2048"
 
 # puppetdb data and generated certs
 VOLUME /opt/puppetlabs/server/data/puppetdb


### PR DESCRIPTION
PuppetDB container logs a warning that it ignores the deprecated `Xloggc` and uses `Xlog:gc` instead of it. 