### PR TITLE
Add 'ARG UBUNTU_CODENAME' to final image build so that Podman correctly interprets PUPPET_DEB environment variable.

### DIFF
--- a/puppetdb/Dockerfile
+++ b/puppetdb/Dockerfile
@@ -96,6 +96,7 @@ ARG UBUNTU_CODENAME
 # hadolint ignore=DL3006
 FROM ${build_type} as final
 
+ARG UBUNTU_CODENAME
 ARG vcs_ref
 ARG build_date
 ARG build_type


### PR DESCRIPTION
This change fixes build failure when using Podman to build the Docker image.

Fixes: #58 