### PR TITLE
verified within a local docker compose

### DIFF
--- a/puppetdb/conf.d/puppetdb.conf
+++ b/puppetdb/conf.d/puppetdb.conf
@@ -1,4 +1,4 @@
 puppetdb: {
   disable-update-checking: 'true'
-  certificate-allowlist: '/etc/puppetlabs/puppetdb/conf.d/certificate-allowlist'
+  certificate-allowlist: certificate-allowlist
 }

--- a/puppetdb/docker-entrypoint.d/30-certificate-allowlist.sh
+++ b/puppetdb/docker-entrypoint.d/30-certificate-allowlist.sh
@@ -3,9 +3,9 @@
 if [ "$PUPPETDB_CERTIFICATE_ALLOWLIST" != "" ]; then
   IFS=','
   for cert in $PUPPETDB_CERTIFICATE_ALLOWLIST; do
-    echo $cert >> /etc/puppetlabs/puppetdb/conf.d/certificate-allowlist
+    echo $cert >> /opt/puppetlabs/server/apps/puppetdb/certificate-allowlist
   done
 else
-  touch /etc/puppetlabs/puppetdb/conf.d/certificate-allowlist
+  touch /opt/puppetlabs/server/apps/puppetdb/certificate-allowlist
 fi
 


### PR DESCRIPTION
certificate-allowlist setting may only be a file name when used in a container

fixes #95 